### PR TITLE
Updated to 01.123

### DIFF
--- a/Src/Gilgame.SEWorkbench.Interop/Blueprint.cs
+++ b/Src/Gilgame.SEWorkbench.Interop/Blueprint.cs
@@ -2,8 +2,8 @@
 using System.IO;
 
 using Sandbox.Common.ObjectBuilders;
-using Sandbox.Common.ObjectBuilders.Definitions;
 using VRage.ObjectBuilders;
+using VRage.Game;
 
 
 namespace Gilgame.SEWorkbench.Interop

--- a/Src/Gilgame.SEWorkbench.Interop/Grid.cs
+++ b/Src/Gilgame.SEWorkbench.Interop/Grid.cs
@@ -1,6 +1,6 @@
-﻿using Sandbox.Common.ObjectBuilders.Definitions;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using VRage.Game;
 
 namespace Gilgame.SEWorkbench.Interop
 {

--- a/Src/Gilgame.SEWorkbench.Interop/SpaceEngineers.cs
+++ b/Src/Gilgame.SEWorkbench.Interop/SpaceEngineers.cs
@@ -31,6 +31,7 @@ using VRage.Utils;
 using VRage.Voxels;
 using VRageMath;
 using VRage.Game;
+using VRage.ModAPI.Ingame;
 
 namespace Gilgame.SEWorkbench.Interop
 {
@@ -194,7 +195,7 @@ namespace Gilgame.SEWorkbench.Interop
             IlChecker.AllowedOperands.Add(typeof(WorkOptions), null);
             IlChecker.AllowedOperands.Add(typeof(Sandbox.ModAPI.Interfaces.ITerminalAction), null);
             IlChecker.AllowedOperands.Add(typeof(IMyInventoryOwner), null);
-            IlChecker.AllowedOperands.Add(typeof(VRage.ModAPI.IMyInventory), null);
+            IlChecker.AllowedOperands.Add(typeof(VRage.ModAPI.Ingame.IMyInventory), null);
             IlChecker.AllowedOperands.Add(typeof(IMyInventoryItem), null);
             IlChecker.AllowedOperands.Add(typeof(ITerminalProperty), null);
             IlChecker.AllowedOperands.Add(typeof(ITerminalProperty<>), null);

--- a/Src/Gilgame.SEWorkbench.Interop/SpaceEngineers.cs
+++ b/Src/Gilgame.SEWorkbench.Interop/SpaceEngineers.cs
@@ -10,8 +10,6 @@ using ParallelTasks;
 using Sandbox.Common.Components;
 using Sandbox.Common.ObjectBuilders;
 using Sandbox.Common.ObjectBuilders.Definitions;
-using Sandbox.Common.ObjectBuilders.Voxels;
-using Sandbox.Common.ObjectBuilders.VRageData;
 using Sandbox.Definitions;
 using Sandbox.Game;
 using Sandbox.Game.Entities;
@@ -32,6 +30,7 @@ using VRage.Plugins;
 using VRage.Utils;
 using VRage.Voxels;
 using VRageMath;
+using VRage.Game;
 
 namespace Gilgame.SEWorkbench.Interop
 {
@@ -195,7 +194,7 @@ namespace Gilgame.SEWorkbench.Interop
             IlChecker.AllowedOperands.Add(typeof(WorkOptions), null);
             IlChecker.AllowedOperands.Add(typeof(Sandbox.ModAPI.Interfaces.ITerminalAction), null);
             IlChecker.AllowedOperands.Add(typeof(IMyInventoryOwner), null);
-            IlChecker.AllowedOperands.Add(typeof(Sandbox.ModAPI.Interfaces.IMyInventory), null);
+            IlChecker.AllowedOperands.Add(typeof(VRage.ModAPI.IMyInventory), null);
             IlChecker.AllowedOperands.Add(typeof(IMyInventoryItem), null);
             IlChecker.AllowedOperands.Add(typeof(ITerminalProperty), null);
             IlChecker.AllowedOperands.Add(typeof(ITerminalProperty<>), null);

--- a/Src/Gilgame.SEWorkbench/ViewModels/GridItemViewModel.cs
+++ b/Src/Gilgame.SEWorkbench/ViewModels/GridItemViewModel.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 
 using Gilgame.SEWorkbench.Models;
-using Sandbox.Common.ObjectBuilders.Definitions;
+using VRage.Game;
 
 namespace Gilgame.SEWorkbench.ViewModels
 {


### PR DESCRIPTION
The namespaces of classes, interfaces etc. have been changed in version
01.123 of Space Engineers. This should fix #17.
